### PR TITLE
About us page added to the other portlets json feed #9

### DIFF
--- a/app/src/main/res/raw/otherportlets.json
+++ b/app/src/main/res/raw/otherportlets.json
@@ -14,6 +14,12 @@
         "description": "Links to sites outside of MySail",
         "url": "http://www.oakland.edu/m/?mobileapp=true",
         "drawable": "links"
+      },
+      {
+        "title": "About Us",
+        "description": "Find out more about Oakland University",
+        "url": "http://www.oakland.edu/about",
+        "drawable": "about"
       }
       ]
    }


### PR DESCRIPTION
This is a temporary place for this feature.
The plan is to add the about us as a footer in the navigation drawer.
